### PR TITLE
GAP Certification Progress Graph on KS Dashboard

### DIFF
--- a/src/screens/ks/FarmReferralForm.js
+++ b/src/screens/ks/FarmReferralForm.js
@@ -272,6 +272,7 @@ class FarmReferralForm extends React.PureComponent {
         </div>
         <div className={classes.form}>
           <h2>Additional Notes</h2>
+          <br />
           <FieldInput
             onChange={this.onChange('additionalNotes')}
             variant="outlined"

--- a/src/screens/shared/farmProfileEdit/FarmProfileEdit.js
+++ b/src/screens/shared/farmProfileEdit/FarmProfileEdit.js
@@ -39,6 +39,15 @@ const styles = {
   },
   button: {
     marginTop: 48
+  },
+  backButton: {
+    marginTop: 100
+  },
+  success: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center'
   }
 };
 class FarmProfileEdit extends React.Component {
@@ -89,11 +98,14 @@ class FarmProfileEdit extends React.Component {
     const { farmId } = match.params;
 
     return (
-      <div className={classes.success}>
-        <br />
-        <h1>Success!</h1>
-        <p>Your changes have been saved.</p>
-        <BackButton label="Back to Farm" href={`/farm/${farmId}`} />
+      <div>
+        <div className={classes.backButton}>
+          <BackButton label=" Back to Farm" href={`/farm/${farmId}`} />
+        </div>
+        <div className={classes.success}>
+          <h1>Success!</h1>
+          <p>Your changes have been saved.</p>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## What's new in this PR?

- Live data into the GAP Certification Progress Graph, which displays the certification progress of all KS-affiliated farms
- A farms falls under the category of its last completed step
- Small tweaks to the editing form success page



### How to Review

Try editing the GAP records of KS-affiliated farms on Airtable and see that the numbers in the graph are still correct. 

[//]: # 'The order in which to review files and 
what to expect when testing locally'
[//]: # '####### YOUR ANSWER BELOW ###########'
[//]: # '############## END ##################'

### Related PRs

[//]: # "Optional - related PRs you're waiting on
/ PRs that will conflict, etc"
[//]: # '####### YOUR ANSWER BELOW ###########'
[//]: # '############## END ##################'

### Next steps

Fix position of gray box when data is not present/loading

<img width="1259" alt="Screen Shot 2021-06-06 at 7 14 05 PM" src="https://user-images.githubusercontent.com/55935661/120950312-6051da00-c6fb-11eb-9a8e-70ef0da24c4f.png">

### Screenshots

<img width="1264" alt="Screen Shot 2021-06-06 at 6 59 15 PM" src="https://user-images.githubusercontent.com/55935661/120949890-64312c80-c6fa-11eb-806e-d96d0f5bc568.png">

CC: @phoebeli23
