### PR TITLE
Andi/filtering

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -116,11 +116,24 @@ export function getPrevMonths(n) {
   return [...Array(n)].map(_i => m.add(1, 'months').format('MMM[\n]YYYY'));
 }
 
+export function getMonthsBetween(startDate, endDate) {
+  const dateStart = moment(startDate);
+  const dateEnd = moment(endDate);
+  const timeValues = [];
+
+  while (dateEnd > dateStart || dateStart.format('M') === dateEnd.format('M')) {
+    timeValues.push(dateStart.format('YYYY-MM'));
+    dateStart.add(1, 'month');
+  }
+  return timeValues;
+}
+
 export default {
   getAllFarmsForKS,
   getDateOptions,
   getPrevMonths,
   getTotalHarvest,
   updateFarmAndCertification,
-  getTotalHarvestData
+  getTotalHarvestData,
+  getMonthsBetween
 };

--- a/src/screens/shared/dateFilterMenu/DateFilterMenu.js
+++ b/src/screens/shared/dateFilterMenu/DateFilterMenu.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import React from 'react';
 
 import { withStyles } from '@material-ui/core/styles';
@@ -37,7 +38,8 @@ class DateFilterMenu extends React.PureComponent {
       filterBy: null,
       showDropdown: false,
       startDate: '',
-      endDate: ''
+      endDate: '',
+      applied: false
     };
   }
 
@@ -61,6 +63,7 @@ class DateFilterMenu extends React.PureComponent {
     // TO-DO onChange needs to take start and end date, if those are changed
     if (startDate && endDate) {
       onChange([startDate, endDate]);
+      this.setState({ applied: true });
     } else {
       onChange(filterBy);
     }
@@ -96,9 +99,17 @@ class DateFilterMenu extends React.PureComponent {
     this.setState({ endDate: event.target.value });
   };
 
+  filterLabel = (startDate, endDate) => {
+    const { applied } = this.state;
+    if (startDate !== '' && endDate !== '' && applied === true) {
+      return startDate.concat(' to ').concat(endDate);
+    }
+    return 'Date Filters';
+  };
+
   render() {
     const { classes } = this.props;
-    const { anchorEl, filterBy, showDropdown } = this.state;
+    const { anchorEl, filterBy, showDropdown, startDate, endDate } = this.state;
 
     return (
       <div>
@@ -110,7 +121,9 @@ class DateFilterMenu extends React.PureComponent {
           startIcon={<CalendarToday />}
           endIcon={<KeyboardArrowDown />}
         >
-          <h3 className={classes.label}>Date Filters</h3>
+          <h3 className={classes.label}>
+            {this.filterLabel(startDate, endDate)}
+          </h3>
         </Button>
         <Popper
           className={classes.popper}

--- a/src/screens/shared/dateFilterMenu/DateFilterMenu.js
+++ b/src/screens/shared/dateFilterMenu/DateFilterMenu.js
@@ -64,7 +64,6 @@ class DateFilterMenu extends React.PureComponent {
     } else {
       onChange(filterBy);
     }
-
     this.setState({ anchorEl: null });
   };
 
@@ -127,7 +126,7 @@ class DateFilterMenu extends React.PureComponent {
             handleStart={this.handleStartDate}
             handleEnd={this.handleEndDate}
           />
-          <ListItem button onClick={this.handleExpand}>
+          {/* <ListItem button onClick={this.handleExpand}>
             <h3 className={classes.options}>Advanced Options</h3>
             {showDropdown ? <ExpandLess /> : <ExpandMore />}
           </ListItem>
@@ -136,7 +135,7 @@ class DateFilterMenu extends React.PureComponent {
               value={filterBy}
               handleClick={this.handleRadioClick}
             />
-          </Collapse>
+          </Collapse> */}
         </Popper>
       </div>
     );

--- a/src/screens/shared/graphs/Graph.js
+++ b/src/screens/shared/graphs/Graph.js
@@ -45,7 +45,7 @@ class Graph extends React.Component {
     };
   }
 
-  getGraphProps = (type, farm) => {
+  getGraphProps = (type, farm, filterBy) => {
     switch (type) {
       case 'certification':
         return {
@@ -55,17 +55,17 @@ class Graph extends React.Component {
       case 'production':
         return {
           label: 'Farm Production History',
-          graph: <ProductionGraph />
+          graph: <ProductionGraph filterBy={filterBy} />
         };
       case 'recentHarvests':
         return {
           label: 'Recent Harvests',
-          graph: <RecentHarvestsGraph farm={farm} />
+          graph: <RecentHarvestsGraph farm={farm} filterBy={filterBy} />
         };
       case 'topItems':
         return {
           label: 'Top 5 Items',
-          graph: <TopItemsGraph farm={farm} />
+          graph: <TopItemsGraph farm={farm} filterBy={filterBy} />
         };
       case 'harvestLogs':
         return {
@@ -83,7 +83,8 @@ class Graph extends React.Component {
 
   render() {
     const { classes, type, farm } = this.props;
-    const { label, graph } = this.getGraphProps(type, farm);
+    const { filterBy } = this.state;
+    const { label, graph } = this.getGraphProps(type, farm, filterBy);
 
     return (
       <div className={classes.root}>

--- a/src/screens/shared/graphs/ProductionGraph.js
+++ b/src/screens/shared/graphs/ProductionGraph.js
@@ -59,7 +59,6 @@ class ProductionGraph extends React.PureComponent {
       dateList: [],
       cropsList: [],
       quantitiesList: [],
-      filterBy: []
     };
   }
 

--- a/src/screens/shared/graphs/ProductionGraph.js
+++ b/src/screens/shared/graphs/ProductionGraph.js
@@ -58,16 +58,14 @@ class ProductionGraph extends React.PureComponent {
     this.state = {
       dateList: [],
       cropsList: [],
-      quantitiesList: [],
+      quantitiesList: []
     };
   }
 
   async componentDidMount() {
-    // Fetch all the "total harvest" records for the specified farm.
+    // Fetch all the "total harvest" records in the database.
     const totalHarvest = await getTotalHarvestData();
-    const dateList = [];
-    const cropsList = [];
-    const quantitiesList = [];
+    const dateList = []; const cropsList = []; const quantitiesList = [];
     for (let h = 0; h < totalHarvest.length; h += 1) {
       const { created, crops, quantities } = totalHarvest[h];
       dateList[h] = created.slice(0, 7); // takes YYYY-MM format

--- a/src/screens/shared/graphs/ProductionGraph.js
+++ b/src/screens/shared/graphs/ProductionGraph.js
@@ -106,7 +106,6 @@ class ProductionGraph extends React.PureComponent {
       }
       recentCrops = new Array(recentDates.length).fill('');
       recentQuantities = new Array(recentDates.length).fill('');
-      console.log(recentDates);
       // DEFAULT: Take the recent 9 months and match them up to the data in `dict`, filling in months without production with 0.
     } else {
       recentDates = getPrevMonths(9);
@@ -218,9 +217,24 @@ class ProductionGraph extends React.PureComponent {
     return [level1, level2, level3, level4, level5other];
   };
 
-  getData = dict => {
+  getData = (dict, filterBy) => {
+    let labels = []
+    if (filterBy !== null) {
+      const months = getMonthsofYear();
+      labels = getMonthsBetween(filterBy[0], filterBy[1]);
+      // Reformatting the dates (2021-03 to Mar\n2021)
+      for (let i = 0; i < labels.length; i += 1) {
+        const year = labels[i].slice(0, 4);
+        // eslint-disable-next-line radix
+        const month = months[parseInt(labels[i].slice(5, 7)) - 1];
+        const dateFormatted = `${String(month)}\n${year}`;
+        labels[i] = dateFormatted;
+      }
+    }
+    else {
+      labels = getPrevMonths(9);
+    }
     // produces data object for each segmenet of stacked bar graph
-    const labels = getPrevMonths(9);
     const level5other = [];
     const level4 = [];
     const level3 = [];
@@ -258,7 +272,7 @@ class ProductionGraph extends React.PureComponent {
       quantitiesList,
       filterBy
     );
-    console.log(lists);
+
     const productionDict = [];
     for (let i = 0; i < lists.dateStringList.length; i += 1) {
       productionDict[i] = [
@@ -269,15 +283,13 @@ class ProductionGraph extends React.PureComponent {
         )
       ];
     }
-    console.log(productionDict);
 
     for (let i = 0; i < productionDict.length; i += 1) {
       productionDict[i][1] = this.sortData(
         productionDict[i][1].cropsToQuantity
       );
     }
-    console.log(productionDict);
-    const data = this.getData(productionDict);
+    const data = this.getData(productionDict, filterBy);
 
     return (
       <VictoryChart padding={48} height={250} width={600}>

--- a/src/screens/shared/graphs/RecentHarvestsGraph.js
+++ b/src/screens/shared/graphs/RecentHarvestsGraph.js
@@ -1,5 +1,10 @@
 import React from 'react';
-import { getPrevMonths, getTotalHarvest, getMonthsofYear } from '@lib/utils';
+import {
+  getPrevMonths,
+  getTotalHarvest,
+  getMonthsofYear,
+  getMonthsBetween
+} from '@lib/utils';
 import FarmProfileGraph from './FarmProfileGraph';
 
 class RecentHarvestsGraph extends React.PureComponent {
@@ -7,13 +12,13 @@ class RecentHarvestsGraph extends React.PureComponent {
     super(props);
     this.state = {
       dateList: [],
-      totalList: []
+      totalList: [],
+      filterBy: []
     };
   }
 
   async componentDidMount() {
     const { farm } = this.props;
-
     // Fetch all the "total harvest" records for the specified farm.
     const totalHarvest =
       farm.totalHarvestIds === undefined // If there are no harvest logs under the farm ID, then return an empty list.
@@ -31,7 +36,7 @@ class RecentHarvestsGraph extends React.PureComponent {
     this.setState({ dateList, totalList });
   }
 
-  getData = (dateList, totalList) => {
+  getData = (dateList, totalList, filterBy) => {
     // Reformatting the dates (2021-03 to Mar\n2021)
     const dict = [];
     const months = getMonthsofYear();
@@ -41,13 +46,31 @@ class RecentHarvestsGraph extends React.PureComponent {
       const month = months[parseInt(dateList[i].slice(5, 7)) - 1];
       const dateFormatted = `${String(month)}\n${year}`;
       // Creating a dictionary mapping dates to its corresponding total production quantity.
+      // Note: Each farm only has 1 "total harvest" record per month, so aggregation of total production pounds is not needed.
       dict[i] = [dateFormatted, totalList[i]];
     }
 
-    // Take the recent 9 months and match them up to the data in `dict`, filling in months without production with 0.
-    // Note: Each farm only has 1 "total harvest" record per month, so aggregation of total production pounds is not needed.
-    const recentDates = getPrevMonths(9);
-    const recentValues = [0, 0, 0, 0, 0, 0, 0, 0, 0];
+    // DURING FILTERING: Parse the selected months
+    let recentDates = [];
+    let recentValues = [];
+    if (filterBy !== null) {
+      recentDates = getMonthsBetween(filterBy[0], filterBy[1]);
+      // Reformatting the dates (2021-03 to Mar\n2021)
+      for (let i = 0; i < recentDates.length; i += 1) {
+        const year = recentDates[i].slice(0, 4);
+        // eslint-disable-next-line radix
+        const month = months[parseInt(recentDates[i].slice(5, 7)) - 1];
+        const dateFormatted = `${String(month)}\n${year}`;
+        recentDates[i] = dateFormatted;
+      }
+      recentValues = new Array(recentDates.length).fill(0);
+      // DEFAULT: Take the recent 9 months and match them up to the data in `dict`, filling in months without production with 0.
+    } else {
+      recentDates = getPrevMonths(9);
+      recentValues = [0, 0, 0, 0, 0, 0, 0, 0, 0];
+    }
+
+    // Fills in the empty 0 values with values from the dictionary
     for (let i = 0; i < dict.length; i += 1) {
       for (let j = 0; j < recentDates.length; j += 1) {
         if (recentDates[j] === dict[i][0]) {
@@ -64,8 +87,9 @@ class RecentHarvestsGraph extends React.PureComponent {
   };
 
   render() {
+    const { filterBy } = this.props;
     const { dateList, totalList } = this.state;
-    const { labels, values } = this.getData(dateList, totalList);
+    const { labels, values } = this.getData(dateList, totalList, filterBy);
 
     return (
       <FarmProfileGraph

--- a/src/screens/shared/graphs/RecentHarvestsGraph.js
+++ b/src/screens/shared/graphs/RecentHarvestsGraph.js
@@ -12,8 +12,7 @@ class RecentHarvestsGraph extends React.PureComponent {
     super(props);
     this.state = {
       dateList: [],
-      totalList: [],
-      filterBy: []
+      totalList: []
     };
   }
 

--- a/src/screens/shared/graphs/TopItemsGraph.js
+++ b/src/screens/shared/graphs/TopItemsGraph.js
@@ -90,6 +90,25 @@ class TopItemsGraph extends React.PureComponent {
     };
   };
 
+  convertToString = (cropsStringList, quantitiesStringList) => {
+    let cropsString = ""; let quantitiesString = "";
+    for (let i = 0; i < cropsStringList.length; i += 1) {
+      if (cropsStringList[i] !== "") {
+        if (cropsString === "") {
+          cropsString = cropsString.concat(cropsStringList[i])
+          quantitiesString = quantitiesString.concat(quantitiesStringList[i])
+        } else {
+          cropsString = cropsString.concat(", ").concat(cropsStringList[i])
+          quantitiesString = quantitiesString.concat(", ").concat(quantitiesStringList[i])
+        }
+      }
+    }
+
+    return {
+      cropsString, quantitiesString
+    }
+  }
+
   // Reformulates data into a dictionary mapping every unique crop and its totaled quantity.
   formulateData = (crops, quantities) => {
     const quantitiesFloats =
@@ -111,40 +130,10 @@ class TopItemsGraph extends React.PureComponent {
       dict = dict.filter(e => e != null); // Removes null values from the dictionary. Length of dictionary shrinks from the total # of inputs to the # of unique crops.
     }
 
-    console.log(dict)
-
     return {
-      cropsToQuantity: dict
+      dict
     };
   };
-
-
-
-  /**
-
-  // Reformulates data into a dictionary mapping every unique crop and its totaled quantity.
-  formulateData = (cropsStr, quantitiesFloats) => {
-    const cropsSplit = cropsStr.split(','); // Splitting string of crops into a list (by comma separation)
-    let dict = [];
-
-    for (let i = 0; i < cropsSplit.length; i += 1) {
-      cropsSplit[i] = cropsSplit[i].replace(/^\s+|\s+$/g, ''); // Trims starting and trailing white spaces
-      if (cropsSplit.slice(0, i).includes(cropsSplit[i])) {
-        for (let j = 0; j < dict.length; j += 1) {
-          if (dict[j][0] === cropsSplit[i]) {
-            dict[j][1] += quantitiesFloats[i]; // If crop has already been added to dictionary, just add the quantity to its current total.
-          }
-        }
-      } else {
-        dict[i] = [cropsSplit[i], quantitiesFloats[i]];
-      }
-      dict = dict.filter(e => e != null); // Removes null values from the dictionary. Length of dictionary shrinks from the total # of inputs to the # of unique crops.
-    }
-
-    return {
-      cropsToQuantity: dict
-    };
-  };  
 
   // Sorts the dictionary of data from highest quantity to lowest quantity and takes the top 5.
   sortData = cropsToQuantity => {
@@ -179,7 +168,6 @@ class TopItemsGraph extends React.PureComponent {
       values: quantitiesSorted.slice(0, 5)
     };
   };
-  */
 
   render() {
     const { dateList, cropsList, quantitiesList } = this.state;
@@ -190,39 +178,16 @@ class TopItemsGraph extends React.PureComponent {
       quantitiesList,
       filterBy
     );
-    console.log(lists)
-    const productionDict = [];
-    /** 
-    for (let i = 0; i < lists.dateStringList.length; i += 1) {
-      productionDict[i] = // [
-        // lists.dateStringList[i],
-        this.formulateData(
-          lists.cropsStringList[i],
-          lists.quantitiesStringList[i]
-        )
-      // ];
-    }
-    console.log(productionDict)
-    
+
+    const {cropsString, quantitiesString} = this.convertToString(lists.cropsStringList, lists.quantitiesStringList)
+    const productionDict = this.formulateData(cropsString, quantitiesString).dict
     const { labels, values } = this.sortData(productionDict);
-    console.log(labels)
-    console.log(values)
-    */
-
-    const labels = ["A", "B", "C", "D", "E"]
-    const values = [1, 2, 3, 4, 5]
-
-    /** 
-    const { cropsStr, quantitiesFloats } = this.state;
-    const { cropsToQuantity } = this.formulateData(cropsStr, quantitiesFloats);
-    const { labels, values } = this.sortData(cropsToQuantity);
-    */
 
     return (
       <FarmProfileGraph
         labels={labels}
         values={values}
-        isEmpty={dateList === []}
+        isEmpty={dateList.length === 0}
       />
     );
   }

--- a/src/screens/shared/graphs/TopItemsGraph.js
+++ b/src/screens/shared/graphs/TopItemsGraph.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getTotalHarvest } from '@lib/utils';
+import { getTotalHarvest, getPrevMonths, getMonthsofYear, getMonthsBetween } from '@lib/utils';
 
 import FarmProfileGraph from './FarmProfileGraph';
 
@@ -7,8 +7,9 @@ class TopItemsGraph extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      cropsStr: '',
-      quantitiesFloats: ''
+      dateList: [],
+      cropsList: [],
+      quantitiesList: []
     };
   }
 
@@ -19,25 +20,107 @@ class TopItemsGraph extends React.PureComponent {
       farm.totalHarvestIds === undefined // If there are no harvest logs under the farm ID, then return an empty list.
         ? []
         : await Promise.all(farm.totalHarvestIds.map(await getTotalHarvest));
-
-    // Iterate through all "total harvest" records to create a string of all crops and a list of their corresponding quantities.
-    let cropsStr = '';
-    let quantitiesStr = '';
+    const dateList = []; const cropsList = []; const quantitiesList = [];
     for (let h = 0; h < totalHarvest.length; h += 1) {
-      const { crops, quantities } = totalHarvest[h];
-      if (h !== 0) {
-        cropsStr += ', ';
-        quantitiesStr += ', ';
-      }
-      cropsStr += crops;
-      quantitiesStr += quantities;
+      const { created, crops, quantities } = totalHarvest[h];
+      dateList[h] = created.slice(0, 7); // takes YYYY-MM format
+      cropsList[h] = crops;
+      quantitiesList[h] = quantities;
     }
-    const quantitiesFloats =
-      quantitiesStr === ''
-        ? []
-        : quantitiesStr.match(/\d+(?:\.\d+)?/g).map(Number); // Converts string to float for the quantities
-    this.setState({ cropsStr, quantitiesFloats });
+    this.setState({ dateList, cropsList, quantitiesList });
   }
+
+  filterByDate = (dateList, cropsList, quantitiesList, filterBy) => {
+    const dict = [];
+    const months = getMonthsofYear();
+    for (let i = 0; i < dateList.length; i += 1) {
+      const year = dateList[i].slice(0, 4);
+      // eslint-disable-next-line radix
+      const month = months[parseInt(dateList[i].slice(5, 7)) - 1];
+      const dateFormatted = `${String(month)}\n${year}`;
+      // Creating a dictionary mapping dates to its corresponding total production quantity.
+      dict[i] = [dateFormatted, cropsList[i], quantitiesList[i]];
+    }
+
+    // Take the recent 9 months and match them up to the data in `dict`, filling in months without production with 0.
+    let recentDates = [];
+    let recentCrops = [];
+    let recentQuantities = [];
+    if (filterBy !== null) {
+      recentDates = getMonthsBetween(filterBy[0], filterBy[1]);
+      // Reformatting the dates (2021-03 to Mar\n2021)
+      for (let i = 0; i < recentDates.length; i += 1) {
+        const year = recentDates[i].slice(0, 4);
+        // eslint-disable-next-line radix
+        const month = months[parseInt(recentDates[i].slice(5, 7)) - 1];
+        const dateFormatted = `${String(month)}\n${year}`;
+        recentDates[i] = dateFormatted;
+      }
+      recentCrops = new Array(recentDates.length).fill('');
+      recentQuantities = new Array(recentDates.length).fill('');
+      // DEFAULT: Take the recent 9 months and match them up to the data in `dict`, filling in months without production with 0.
+    } else {
+      recentDates = getPrevMonths(9);
+      recentCrops = ['', '', '', '', '', '', '', '', ''];
+      recentQuantities = ['', '', '', '', '', '', '', '', ''];
+    }
+
+    for (let i = 0; i < dict.length; i += 1) {
+      for (let j = 0; j < recentDates.length; j += 1) {
+        if (recentDates[j] === dict[i][0]) {
+          if (recentCrops[j] === '' && recentQuantities[j] === '') {
+            // eslint-disable-next-line prefer-destructuring
+            recentCrops[j] = dict[i][1];
+            // eslint-disable-next-line prefer-destructuring
+            recentQuantities[j] = dict[i][2];
+          } else {
+            // eslint-disable-next-line prefer-destructuring
+            recentCrops[j] += ', '.concat(dict[i][1]);
+            // eslint-disable-next-line prefer-destructuring
+            recentQuantities[j] += ', '.concat(dict[i][2]);
+          }
+        }
+      }
+    }
+
+    return {
+      dateStringList: recentDates,
+      cropsStringList: recentCrops,
+      quantitiesStringList: recentQuantities
+    };
+  };
+
+  // Reformulates data into a dictionary mapping every unique crop and its totaled quantity.
+  formulateData = (crops, quantities) => {
+    const quantitiesFloats =
+      quantities === '' ? [] : quantities.match(/\d+(?:\.\d+)?/g).map(Number); // Converts string to float for the quantities
+    const cropsSplit = crops.split(','); // Splitting string of crops into a list (by comma separation)
+
+    let dict = [];
+    for (let i = 0; i < cropsSplit.length; i += 1) {
+      cropsSplit[i] = cropsSplit[i].replace(/^\s+|\s+$/g, ''); // Trims starting and trailing white spaces
+      if (cropsSplit.slice(0, i).includes(cropsSplit[i])) {
+        for (let j = 0; j < dict.length; j += 1) {
+          if (dict[j][0] === cropsSplit[i]) {
+            dict[j][1] += quantitiesFloats[i]; // If crop has already been added to dictionary, just add the quantity to its current total.
+          }
+        }
+      } else {
+        dict[i] = [cropsSplit[i], quantitiesFloats[i]];
+      }
+      dict = dict.filter(e => e != null); // Removes null values from the dictionary. Length of dictionary shrinks from the total # of inputs to the # of unique crops.
+    }
+
+    console.log(dict)
+
+    return {
+      cropsToQuantity: dict
+    };
+  };
+
+
+
+  /**
 
   // Reformulates data into a dictionary mapping every unique crop and its totaled quantity.
   formulateData = (cropsStr, quantitiesFloats) => {
@@ -61,7 +144,7 @@ class TopItemsGraph extends React.PureComponent {
     return {
       cropsToQuantity: dict
     };
-  };
+  };  
 
   // Sorts the dictionary of data from highest quantity to lowest quantity and takes the top 5.
   sortData = cropsToQuantity => {
@@ -96,17 +179,50 @@ class TopItemsGraph extends React.PureComponent {
       values: quantitiesSorted.slice(0, 5)
     };
   };
+  */
 
   render() {
+    const { dateList, cropsList, quantitiesList } = this.state;
+    const { filterBy } = this.props;
+    const lists = this.filterByDate(
+      dateList,
+      cropsList,
+      quantitiesList,
+      filterBy
+    );
+    console.log(lists)
+    const productionDict = [];
+    /** 
+    for (let i = 0; i < lists.dateStringList.length; i += 1) {
+      productionDict[i] = // [
+        // lists.dateStringList[i],
+        this.formulateData(
+          lists.cropsStringList[i],
+          lists.quantitiesStringList[i]
+        )
+      // ];
+    }
+    console.log(productionDict)
+    
+    const { labels, values } = this.sortData(productionDict);
+    console.log(labels)
+    console.log(values)
+    */
+
+    const labels = ["A", "B", "C", "D", "E"]
+    const values = [1, 2, 3, 4, 5]
+
+    /** 
     const { cropsStr, quantitiesFloats } = this.state;
     const { cropsToQuantity } = this.formulateData(cropsStr, quantitiesFloats);
     const { labels, values } = this.sortData(cropsToQuantity);
+    */
 
     return (
       <FarmProfileGraph
         labels={labels}
         values={values}
-        isEmpty={cropsStr === ''}
+        isEmpty={dateList === []}
       />
     );
   }

--- a/src/screens/shared/graphs/TopItemsGraph.js
+++ b/src/screens/shared/graphs/TopItemsGraph.js
@@ -67,7 +67,6 @@ class TopItemsGraph extends React.PureComponent {
   sortData = cropsToQuantity => {
     let dict = cropsToQuantity;
     dict = dict.sort((a, b) => b[1] - a[1]);
-    console.log(dict);
 
     const cropsSorted = [];
     const quantitiesSorted = [];
@@ -101,8 +100,6 @@ class TopItemsGraph extends React.PureComponent {
   render() {
     const { cropsStr, quantitiesFloats } = this.state;
     const { cropsToQuantity } = this.formulateData(cropsStr, quantitiesFloats);
-    console.log(cropsToQuantity);
-    console.log(typeof cropsToQuantity);
     const { labels, values } = this.sortData(cropsToQuantity);
 
     return (


### PR DESCRIPTION
[//]: # "These comments meant for your reference, they are invisible and don't need to be deleted"

## What's new in this PR?

[//]: # '####### YOUR ANSWER BELOW ###########'
Implemented **Filtering** for Farm Production History Graph (ProductionGraph.js), Top Items Graph (TopItemsGraph.js), and Recent Harvests Graph (RecentHarvestsGraph.js). The filtering takes the inputted dates and filters them by the month interval specified.

Additionally, I implemented an extra feature on changing the filter's header when dates are applied to the filter selection. It changes from "Date Filters" to "[start date] to [end date]". 

(Andi's Last PR thanks for all the good times!)

### How to Review

[//]: # 'The order in which to review files and 
what to expect when testing locally'
[//]: # '####### YOUR ANSWER BELOW ###########'
- Farm Production History Graph (ProductionGraph.js)
- Top Items Graph (TopItemsGraph.js)
- Recent Harvests Graph (RecentHarvestsGraph.js)
- Date Filter Menu (DateFilterMenu.js)
- passing on the filter's startDate and endDate on from the Data Filter Menu to the Graphs (Graph.js). 

### Related PRs

[//]: # "Optional - related PRs you're waiting on
/ PRs that will conflict, etc"
[//]: # '####### YOUR ANSWER BELOW ###########'
[//]: # '############## END ##################'

### Next steps

[//]: # "What doesn't work yet, what's NOT in this 
PR/has to be done "
[//]: # '####### YOUR ANSWER BELOW ###########'
- Additional Options was commented out from the file as it does not work unless implemented. Currently, it will freeze if an additional option is selected and the filter is applied. Once implemented, it will work again. 
![image](https://user-images.githubusercontent.com/43193441/122133464-bb29b680-ce0a-11eb-9316-10169953d865.png)

- VictoryGraphs are still buggy with 3 or less X values (categories/dates). 
![image](https://user-images.githubusercontent.com/43193441/122133422-a51bf600-ce0a-11eb-88ac-055c54682df0.png)

- Filter Menu should save/cache the Applied Filtered Dates so that a user can pick up where they left off if they choose to filter again. 
![image](https://user-images.githubusercontent.com/43193441/122133370-92a1bc80-ce0a-11eb-9285-bbe81cf7429c.png)

- Filtering for the other two graphs have not been implemented (HarvestLogs and GAP Certification).

- Not very related to this PR but related to the page. There's a bug with the See More button under the Harvest Logs graph that affects the rest of the page too. 
![image](https://user-images.githubusercontent.com/43193441/122134196-232ccc80-ce0c-11eb-9040-1b1ae52f34c7.png)

- Stretch Feature: Could create a Top # Items as a filter in the Top Items Graph.

### Screenshots

[//]: # '#### YOUR SCREENSHOTS BELOW ########'
![image](https://user-images.githubusercontent.com/43193441/122134465-a1896e80-ce0c-11eb-8e64-1af0fdeec2e4.png)
![image](https://user-images.githubusercontent.com/43193441/122133151-2de66200-ce0a-11eb-8304-cb4a503d8a2a.png)
![image](https://user-images.githubusercontent.com/43193441/122134485-afd78a80-ce0c-11eb-9711-ff239b797f73.png)

### Design Status

[//]: # 'If this is a frontend PR, what is the expected 
status of the UI in this PR (lo, mid, high- fi?'
[//]: # '####### LOFI/MIDFI/HIFI ###########'
[//]: # '############## END ##################'

CC: @phoebeli23
